### PR TITLE
Pass method as a attribute

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -7,6 +7,7 @@ const now = moment().utc()
 const defaults = {
   title: 'Untitled event',
   productId: 'adamgibbons/ics',
+  method: 'PUBLISH',
   uid: uuidv1(),
   timestamp: setDateWithUTCtime([
     now.get('year'),

--- a/src/pipeline/build.js
+++ b/src/pipeline/build.js
@@ -5,6 +5,7 @@ export default function buildEvent (attributes = {}) {
   const {
     title,
     productId,
+    method,
     uid,
     start,
     startType,

--- a/src/pipeline/format.js
+++ b/src/pipeline/format.js
@@ -15,6 +15,7 @@ export default function formatEvent(attributes = {}) {
   const {
     title,
     productId,
+    method,
     uid,
     timestamp,
     start,
@@ -37,7 +38,7 @@ export default function formatEvent(attributes = {}) {
   icsFormat += 'VERSION:2.0\r\n'
   icsFormat += 'CALSCALE:GREGORIAN\r\n'
   icsFormat += foldLine(`PRODID:${productId}`) + '\r\n'
-  icsFormat += `METHOD:REQUEST\r\n`
+  icsFormat += foldLine(`METHOD:${method}`) + '\r\n'
   icsFormat += `X-PUBLISHED-TTL:PT1H\r\n`
   icsFormat += 'BEGIN:VEVENT\r\n'
   icsFormat += `UID:${uid}\r\n`

--- a/src/schema/index.js
+++ b/src/schema/index.js
@@ -47,6 +47,7 @@ const schema = Joi.object().keys({
   timestamp: Joi.any(),
   title: Joi.string(),
   productId: Joi.string(),
+  method: Joi.string(),
   uid: Joi.string().required(),
   start: dateTimeSchema.required(),
   duration: durationSchema,

--- a/test/pipeline/build.spec.js
+++ b/test/pipeline/build.spec.js
@@ -22,6 +22,16 @@ describe('pipeline.build properties', () => {
       expect(event.productId).to.equal('myProductId')
     })
   })
+  describe('method', () => {
+    it('sets a default', () => {
+      const event = buildEvent()
+      expect(event.method).to.equal('adamgibbons/ics')
+    })
+    it('sets a product id', () => {
+      const event = buildEvent({ method: 'REQUEST' })
+      expect(event.method).to.equal('REQUEST')
+    })
+  })
   describe('uid', () => {
     it('sets a default', () => {
       const event = buildEvent()

--- a/test/pipeline/build.spec.js
+++ b/test/pipeline/build.spec.js
@@ -25,9 +25,9 @@ describe('pipeline.build properties', () => {
   describe('method', () => {
     it('sets a default', () => {
       const event = buildEvent()
-      expect(event.method).to.equal('adamgibbons/ics')
+      expect(event.method).to.equal('PUBLISH')
     })
-    it('sets a product id', () => {
+    it('sets a method', () => {
       const event = buildEvent({ method: 'REQUEST' })
       expect(event.method).to.equal('REQUEST')
     })

--- a/test/pipeline/format.spec.js
+++ b/test/pipeline/format.spec.js
@@ -125,6 +125,7 @@ describe('pipeline.formatEvent', () => {
   it('never writes lines longer than 75 characters, excluding CRLF', () => {
     const formattedEvent = formatEvent({
       productId: '*'.repeat(1000),
+      method: '*'.repeat(1000),
       title: '*'.repeat(1000),
       description: '*'.repeat(1000),
       url: '*'.repeat(1000),


### PR DESCRIPTION
Now the method can be passed as an atrribute to allow other methods
described on the RFC